### PR TITLE
Add Pipenv (docker prerequisite)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 mysql-connector-python = "*"
-cmyui = ">=1.1.0"
+cmyui = ">=1.1.6"
 py3rijndael = ">=0.3.3"
 
 [requires]

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+mysql-connector-python = "*"
+cmyui = ">=1.1.0"
+py3rijndael = ">=0.3.3"
+
+[requires]
+python_version = "3.8"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ If you have any difficulties setting up gulag, you can contact me via Discord @ 
 git clone https://github.com/cmyui/gulag.gitcd gulag
 cd gulag
 
-# Install python requirements.
-pip3 install -r requirements.txt
+# Install pipenv and requirements.
+python3 -m pip install pipenv --user
+python3 -m pipenv install
 
 # Import the database structure.
 # NOTE: create an empty database before doing this.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-mysql-connector-python
-cmyui>=1.1.0
-py3rijndael>=0.3.3


### PR DESCRIPTION
This makes it a lot easier to manage dependencies. You will still need to generate a lockfile (just run `pipenv lock`).