### PR TITLE
Tiny fix: correct byte length

### DIFF
--- a/packets.py
+++ b/packets.py
@@ -465,7 +465,7 @@ def write_uleb128(num: int) -> bytearray:
 
 def write_string(s: str) -> bytearray:
     """ Write `s` into bytes (ULEB128 & string). """
-    if (length := len(s)) > 0:
+    if (length := len(s.encode())) > 0:
         # non-empty string
         data = b'\x0b' + write_uleb128(length) + s.encode()
     else:


### PR DESCRIPTION
When trying to write non-English characters to the packets, it will get an incorrect length.
Incorrect length will cause the osu! client to not display some packets normally (such as notifications)

len("h") -> 1 √
len("嗨") -> 1 ×
len("嗨".encode()) -> 3 √