### PR TITLE
made < into <=

### DIFF
--- a/domains/osu.py
+++ b/domains/osu.py
@@ -2019,7 +2019,7 @@ async def register_account(conn: Connection) -> Optional[bytes]:
     # - be within 8-32 characters in length
     # - have more than 3 unique characters
     # - not be in the config's `disallowed_passwords` list
-    if not 8 < len(pw_txt) <= 32:
+    if not 8 <= len(pw_txt) <= 32:
         errors['password'].append('Must be 8-32 characters in length.')
 
     if len(set(pw_txt)) <= 3:


### PR DESCRIPTION
Bancho's implementation of the password length check had a minimum of 8 characters. This means that a password can be equal to or greater than 8. Currently, this is not the case. 




(very important pull request lol)