### PR TITLE
Moved Bancho domain regex pattern to regexes.py and cleaned !switchserv

### DIFF
--- a/constants/commands.py
+++ b/constants/commands.py
@@ -513,8 +513,11 @@ async def switchserv(p: 'Player', c: Messageable, msg: Sequence[str]) -> str:
     if len(msg) != 1:
         return 'Invalid syntax: !switch <endpoint>'
 
+    if not regexes.bancho_url.match(msg[0]):
+        return 'Invalid URL: can only switch to c[e4-6].ppy.sh domains'
+
     p.enqueue(packets.switchTournamentServer(msg[0]))
-    return 'Have a nice journey..'
+    return f'Switching to {msg}... Have a nice journey!'
 
 # rest in peace rtx - oct 2020 :candle:
 #@command(Privileges.Dangerous, hidden=True)

--- a/constants/regexes.py
+++ b/constants/regexes.py
@@ -3,7 +3,7 @@
 from re import compile as rcomp
 from re import IGNORECASE
 
-__all__ = ('mapfile', 'osu_ver', 'username', 'email', 'now_playing')
+__all__ = ('mapfile', 'osu_ver', 'username', 'email', 'now_playing', 'bancho_url')
 
 mapfile = rcomp(r'^(?P<artist>.+) - (?P<title>.+) \((?P<creator>.+)\) \[(?P<version>.+)\]\.osu$')
 osu_ver = rcomp(r'^b(?P<ver>\d{8})(?:\.(?P<subver>\d))?(?:beta|cuttingedge|dev)?$')
@@ -25,3 +25,4 @@ tourney_matchname = rcomp(
     flags = IGNORECASE
 )
 mappool_pick = rcomp(r'^([a-zA-Z]+)([0-9]+)$')
+bancho_url = rcomp(r'^c[e4-6]?\.ppy\.sh$')

--- a/domains/cho.py
+++ b/domains/cho.py
@@ -37,7 +37,7 @@ from utils.misc import make_safe_name
 
 """ Bancho: handle connections from the osu! client """
 
-domain = Domain(re.compile(r'^c[e4-6]?\.ppy\.sh$'))
+domain = Domain(regexes.bancho_url)
 
 @domain.route('/')
 async def bancho_http_handler(conn: Connection) -> bytes:

--- a/domains/osu.py
+++ b/domains/osu.py
@@ -2019,7 +2019,7 @@ async def register_account(conn: Connection) -> Optional[bytes]:
     # - be within 8-32 characters in length
     # - have more than 3 unique characters
     # - not be in the config's `disallowed_passwords` list
-    if not 8 < len(pw_txt) <= 32:
+    if not 8 <= len(pw_txt) <= 32:
         errors['password'].append('Must be 8-32 characters in length.')
 
     if len(set(pw_txt)) <= 3:


### PR DESCRIPTION
### Bancho Regex Refactor
I think there can be applications where the Bancho domain regex can be used. Previously, the only location that this was located in was the [domain object initialization in cho.py](https://github.com/cmyui/gulag/blob/master/domains/cho.py#L40). While it works as an ad-hoc solution, we should consider future implementations that can use this regex. Therefore, I moved this pattern into constants/regexes.py so it can be referenced by the project.

### !switchserv modifications
osu!client's current implementation of the redirect cho packet is only limited to valid .ppy.sh Bancho subdomains. 

https://github.com/cmyui/gulag/blob/8febf963a9234994db3aa777e9e01383dcb49260/constants/commands.py#L507-L509

Using the edit previously described, I now check if the domain is a valid Bancho domain. Here is me testing it.

![image](https://user-images.githubusercontent.com/32436024/107859696-2a65ae80-6e09-11eb-8cd7-1aa54d719861.png)

The redirect notif popped up and I seemed to be reconnected.
