### PR TITLE
Upgrade Channels

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 cmyui
+Copyright (c) 2021 cmyui
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/domains/cho.py
+++ b/domains/cho.py
@@ -1104,16 +1104,20 @@ class MatchChangeSettings(BanchoPacket, type=Packets.OSU_MATCH_CHANGE_SETTINGS):
                        f'!mp teams {_team} command.')
                 m.chat.send_bot(msg)
             else:
-                is_solo = self.new.team_type  in (MatchTeamTypes.head_to_head,
-                                          MatchTeamTypes.tag_coop)
+                # find the new appropriate default team.
+                # defaults are (ffa: neutral, teams: red).
+                if m.team_type in (MatchTeamTypes.head_to_head,
+                                MatchTeamTypes.tag_coop):
+                    new_t = MatchTeams.neutral
+                else:
+                    new_t = MatchTeams.red
 
                 # change each active slots team to
                 # fit the correspoding team type.
                 for s in m.slots:
                     if s.status & SlotStatus.has_player:
-                        # randomize new team placement (could be used as a mechanic)
-                        s.team = MatchTeams.neutral if is_solo else MatchTeams.red
-
+                        s.team = new_t
+                
                 # change the matches'.
                 m.team_type = self.new.team_type
 

--- a/domains/cho.py
+++ b/domains/cho.py
@@ -191,15 +191,15 @@ class SendMessage(BanchoPacket, type=Packets.OSU_SEND_PUBLIC_MESSAGE):
         t_chan = None
 
         for chan in p.channels:
-            if chan.name == target:
+            if chan.name == recipient:
                 t_chan = chan
-
-        if not t_chan and (t_chan := glob.channels[target]):
-            log(f"{p} is not part of {target} and yet sent message to {target}????", Ansi.LYELLOW)
-
-        if not t_chan:
-            log(f'{p} wrote to non-existent {recipient}.', Ansi.LYELLOW)
+        else:
+            log(f"{p} sent a message to a channel they're not a part of.", Ansi.LRED)
             return
+
+        # if not t_chan:
+        #     log(f'{p} wrote to non-existent {recipient}.', Ansi.LYELLOW)
+        #     return
 
         if p.priv & t_chan.write_priv != t_chan.write_priv:
             log(f'{p} wrote to {recipient} with insufficient privileges.')
@@ -898,7 +898,7 @@ class MatchCreate(BanchoPacket, type=Packets.OSU_CREATE_MATCH):
         # to the global channel list as
         # an instanced channel.
         chan = Channel(
-            name="#multiplayer",
+            name = "#multiplayer",
             id_name = f'#multi_{self.match.id}',
             topic = f"MID {self.match.id}'s multiplayer channel.",
             auto_join = False,
@@ -1104,7 +1104,7 @@ class MatchChangeSettings(BanchoPacket, type=Packets.OSU_MATCH_CHANGE_SETTINGS):
                        f'!mp teams {_team} command.')
                 m.chat.send_bot(msg)
             else:
-                isSolo = self.new.team_type  in (MatchTeamTypes.head_to_head,
+                is_solo = self.new.team_type  in (MatchTeamTypes.head_to_head,
                                           MatchTeamTypes.tag_coop)
 
                 # change each active slots team to
@@ -1112,8 +1112,7 @@ class MatchChangeSettings(BanchoPacket, type=Packets.OSU_MATCH_CHANGE_SETTINGS):
                 for s in m.slots:
                     if s.status & SlotStatus.has_player:
                         # randomize new team placement (could be used as a mechanic)
-                        s.team = MatchTeams.neutral if isSolo else \
-                        MatchTeams.red if r.random() > 0.5 else MatchTeams.blue
+                        s.team = MatchTeams.neutral if is_solo else MatchTeams.red
 
                 # change the matches'.
                 m.team_type = self.new.team_type

--- a/domains/cho.py
+++ b/domains/cho.py
@@ -6,6 +6,7 @@ import time
 from datetime import datetime as dt
 from datetime import timedelta as td
 from typing import Callable
+import random as r
 
 import bcrypt
 from cmyui import _isdecimal
@@ -928,7 +929,8 @@ class MatchCreate(BanchoPacket, type=Packets.OSU_CREATE_MATCH):
         # to the global channel list as
         # an instanced channel.
         chan = Channel(
-            name = f'#multi_{self.match.id}',
+            name="#multiplayer",
+            id_name = f'#multi_{self.match.id}',
             topic = f"MID {self.match.id}'s multiplayer channel.",
             auto_join = False,
             instance = True
@@ -1133,19 +1135,15 @@ class MatchChangeSettings(BanchoPacket, type=Packets.OSU_MATCH_CHANGE_SETTINGS):
                        f'!mp teams {_team} command.')
                 m.chat.send_bot(msg)
             else:
-                # find the new appropriate default team.
-                # defaults are (ffa: neutral, teams: red).
-                if self.new.team_type in (MatchTeamTypes.head_to_head,
-                                          MatchTeamTypes.tag_coop):
-                    new_t = MatchTeams.neutral
-                else:
-                    new_t = MatchTeams.red
+                isSolo = self.new.team_type  in (MatchTeamTypes.head_to_head,
+                                          MatchTeamTypes.tag_coop)
 
                 # change each active slots team to
                 # fit the correspoding team type.
                 for s in m.slots:
                     if s.status & SlotStatus.has_player:
-                        s.team = new_t
+                        s.team = MatchTeams.neutral if isSolo else \
+                        MatchTeams.red if r.random() > 0.5 else MatchTeams.blue
 
                 # change the matches'.
                 m.team_type = self.new.team_type

--- a/domains/cho.py
+++ b/domains/cho.py
@@ -181,29 +181,19 @@ class SendMessage(BanchoPacket, type=Packets.OSU_SEND_PUBLIC_MESSAGE):
             log(f'{p} sent a message while silenced.', Ansi.LYELLOW)
             return
 
+
         # remove leading/trailing whitespace
         msg = self.msg.msg.strip()
         target = self.msg.target
 
-        if target == '#spectator':
-            if p.spectating:
-                # we are spectating someone
-                spec_id = p.spectating.id
-            elif p.spectators:
-                # we are being spectated
-                spec_id = p.id
-            else:
-                return
+        t_chan = None
 
-            t_chan = glob.channels[f'#spec_{spec_id}']
-        elif target == '#multiplayer':
-            if not p.match:
-                # they're not in a match?
-                return
+        for chan in p.channels:
+            if chan.name == target:
+                t_chan = chan
 
-            t_chan = p.match.chat
-        else:
-            t_chan = glob.channels[target]
+        if not t_chan and (t_chan := glob.channels[target]):
+            log(f"{p} is not part of {target} and yet sent message to {target}????", Ansi.LYELLOW)
 
         if not t_chan:
             log(f'{p} wrote to non-existent {target}.', Ansi.LYELLOW)
@@ -1142,6 +1132,7 @@ class MatchChangeSettings(BanchoPacket, type=Packets.OSU_MATCH_CHANGE_SETTINGS):
                 # fit the correspoding team type.
                 for s in m.slots:
                     if s.status & SlotStatus.has_player:
+                        # randomize new team placement (could be used as a mechanic)
                         s.team = MatchTeams.neutral if isSolo else \
                         MatchTeams.red if r.random() > 0.5 else MatchTeams.blue
 

--- a/objects/channel.py
+++ b/objects/channel.py
@@ -16,53 +16,59 @@ class Channel:
 
     Possibly confusing attributes
     -----------
-    _name: `str`
+    name: `str`
         A name string of the channel.
-        The cls.`name` property wraps handling for '#multiplayer' and
-        '#spectator' when communicating with the osu! client; only use
-        this attr when you need the channel's true name; otherwise you
-        should use the `name` property described below.
+        The cls.`name` attribute is what the client sees (i.e. #multiplayer). This does not
+        contain identification information pertaining to the channel, only information for
+        the client.
+
+    id_name: `str`
+        A special name string of the channel.
+        The cls.`id_name` attribute contains indentification of the channel and is meant for internal
+        use only (i.e. #multi_231). This attribute are usually only set by instance channels (see below).
+        If no `id_name` is specified, cls.`id_name` will be cls.`name`.
 
     instance: `bool`
         Instanced channels are deleted when all players have left;
         this is useful for things like multiplayer, spectator, etc.
     """
-    __slots__ = ('_name', 'topic', 'players',
+    __slots__ = ('name', 'topic', 'players',
                  'read_priv', 'write_priv',
-                 'auto_join', 'instance')
+                 'auto_join', 'instance', 'id_name')
 
     def __init__(self, name: str, topic: str,
+                 id_name: str = None,
                  read_priv: Privileges = Privileges.Normal,
                  write_priv: Privileges = Privileges.Normal,
                  auto_join: bool = True,
                  instance: bool = False) -> None:
-        self._name = name # 'real' name ('#{multi/spec}_{id}')
+        self.name = name
         self.topic = topic
         self.read_priv = read_priv
         self.write_priv = write_priv
         self.auto_join = auto_join
         self.instance = instance
 
-        self.players: list['Player'] = []
-
-    @property
-    def name(self) -> str:
-        if self._name.startswith('#spec_'):
-            return '#spectator'
-        elif self._name.startswith('#multi_'):
-            return '#multiplayer'
+        if id_name is None:
+            self.id_name = self.name
         else:
-            return self._name
+            self.id_name = id_name
+
+        self.players: list['Player'] = set()
+
 
     @property
     def basic_info(self) -> tuple[str, str, int]:
-        return (self.name, self.topic, len(self.players))
+        return (self.name, self.topic, len(self))
 
     def __repr__(self) -> str:
-        return f'<{self._name}>'
+        return f'<{self.name}>'
 
     def __contains__(self, p: 'Player') -> bool:
         return p in self.players
+
+    def __len__(self) -> int:
+        return len(self.players)
 
     def send(self, msg: str, sender: 'Player',
              to_self: bool = False) -> None:
@@ -98,13 +104,13 @@ class Channel:
 
     def append(self, p: 'Player') -> None:
         """Add `p` to the channel's players."""
-        self.players.append(p)
+        self.players.add(p)
 
     def remove(self, p: 'Player') -> None:
         """Remove `p` from the channel's players."""
         self.players.remove(p)
 
-        if len(self.players) == 0 and self.instance:
+        if len(self) == 0 and self.instance:
             # if it's an instance channel and this
             # is the last member leaving, just remove
             # the channel from the global list.

--- a/objects/collections.py
+++ b/objects/collections.py
@@ -57,12 +57,12 @@ class ChannelList(list):
         # XXX: we use the "real" name, aka
         # #multi_1 instead of #multiplayer
         # #spect_1 instead of #spectator.
-        return f'[{", ".join(c._name for c in self)}]'
+        return f'[{", ".join(c.id_name for c in self)}]'
 
     def get(self, name: str) -> Optional['Channel']:
-        """Get a channel from the list by `name`."""
+        """Get a channel from the list by `id_name`."""
         for c in self:
-            if c._name == name:
+            if c.id_name == name:
                 return c
 
     def append(self, c: 'Channel') -> None:

--- a/objects/match.py
+++ b/objects/match.py
@@ -205,7 +205,7 @@ class Match:
         'id', 'name', 'passwd', 'host', '_refs',
         'map_id', 'map_md5', 'map_name',
         'mods', 'freemods', 'mode',
-        'chat', 'red_chat', 'blue_chat', 'slots',
+        'chat', 'slots',
         #'type',
         'team_type', 'win_condition',
         'in_progress', 'seed',
@@ -234,9 +234,6 @@ class Match:
         self.freemods = False
 
         self.chat: Optional['Channel'] = None # multiplayer
-        self.red_chat: Optional['Channel'] = None # red team
-        self.blue_chat: Optional['Channel'] = None # blue team
-
 
         self.slots = [Slot() for _ in range(16)]
 

--- a/objects/match.py
+++ b/objects/match.py
@@ -205,7 +205,7 @@ class Match:
         'id', 'name', 'passwd', 'host', '_refs',
         'map_id', 'map_md5', 'map_name',
         'mods', 'freemods', 'mode',
-        'chat', 'slots',
+        'chat', 'red_chat', 'blue_chat', 'slots',
         #'type',
         'team_type', 'win_condition',
         'in_progress', 'seed',
@@ -233,7 +233,11 @@ class Match:
         self.mode = GameMode.vn_std
         self.freemods = False
 
-        self.chat: Optional['Channel'] = None #multiplayer
+        self.chat: Optional['Channel'] = None # multiplayer
+        self.red_chat: Optional['Channel'] = None # red team
+        self.blue_chat: Optional['Channel'] = None # blue team
+
+
         self.slots = [Slot() for _ in range(16)]
 
         #self.type = MatchTypes.standard

--- a/objects/player.py
+++ b/objects/player.py
@@ -598,7 +598,7 @@ class Player:
             return False
 
         # lobby can only be interacted with while in mp lobby.
-        if c._name == '#lobby' and not self.in_lobby:
+        if c.name == '#lobby' and not self.in_lobby:
             return False
 
         c.append(self) # add to c.players
@@ -646,7 +646,8 @@ class Player:
         if not (spec_chan := glob.channels[chan_name]):
             # spectator chan doesn't exist, create it.
             spec_chan = Channel(
-                name = chan_name,
+                name = "#spectator",
+                id_name = chan_name,
                 topic = f"{self.name}'s spectator channel.'",
                 auto_join = False,
                 instance = True


### PR DESCRIPTION
### Main Addition
Channels now use id_name for identification instead of _name and the name property. This opens up the possibility for more esoteric channels (i.e. clan channels). 

### Extras
- When changing to a new team or when a match switches to a team mode, teams are randomly assigned blue or red (coinfip)
- Player channel list is now a set