### PR TITLE
Simplify getting user's IPA

### DIFF
--- a/domains/cho.py
+++ b/domains/cho.py
@@ -65,15 +65,8 @@ async def bancho_http_handler(conn: Connection) -> bytes:
 
 @domain.route('/', methods=['POST'])
 async def bancho_handler(conn: Connection) -> bytes:
-    if 'CF-Connecting-IP' in conn.headers:
-        ip = conn.headers['CF-Connecting-IP']
-    else:
-        # if the request has been forwarded, get the origin
-        forwards = conn.headers['X-Forwarded-For'].split(',')
-        if len(forwards) != 1:
-            ip = forwards[0]
-        else:
-            ip = conn.headers['X-Real-IP']
+    ip = conn.headers['X-Forwarded-For'] and conn.headers['X-Forwarded-For'].split(',')[0]
+    # TODO: use client ip address if no reverse proxy
 
     if (
         'User-Agent' not in conn.headers or

--- a/domains/osu.py
+++ b/domains/osu.py
@@ -2430,15 +2430,8 @@ async def register_account(
             else:
                 # backup method, get the user's ip and
                 # do a db lookup to get their country.
-                if 'CF-Connecting-IP' in conn.headers:
-                    ip = conn.headers['CF-Connecting-IP']
-                else:
-                    # if the request has been forwarded, get the origin
-                    forwards = conn.headers['X-Forwarded-For'].split(',')
-                    if len(forwards) != 1:
-                        ip = forwards[0]
-                    else:
-                        ip = conn.headers['X-Real-IP']
+                ip = conn.headers['X-Forwarded-For'] and conn.headers['X-Forwarded-For'].split(',')[0]
+                # TODO: use client ip address if no reverse proxy
 
                 if ip != '127.0.0.1':
                     if glob.geoloc_db is not None:

--- a/ext/nginx.conf
+++ b/ext/nginx.conf
@@ -25,7 +25,6 @@ server {
 
 	location / {
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_set_header X-Real-IP  $remote_addr;
 		proxy_set_header Host $http_host;
 		proxy_redirect off;
 		proxy_pass http://gulag;
@@ -59,7 +58,6 @@ server {
 #
 #	location / {
 #		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-#		proxy_set_header X-Real-IP  $remote_addr;
 #		proxy_set_header Host $http_host;
 #		proxy_redirect off;
 #		proxy_pass http://gulag;


### PR DESCRIPTION
x-forwarded-for is all u need, keep it simple and dont bother with the other random ones. Unless u want to prevent IPA spoofing but that will add some complexity.

Ideally it'd use the client socket address if there is no reverse proxy but i guess nobody's gonna be doing that.