### PR TITLE
Remove CF-Connecting-IP for security purposes

### DIFF
--- a/domains/cho.py
+++ b/domains/cho.py
@@ -78,13 +78,9 @@ async def bancho_http_handler(conn: Connection) -> bytes:
 
 @domain.route('/', methods=['POST'])
 async def bancho_handler(conn: Connection) -> bytes:
-    if 'CF-Connecting-IP' in conn.headers:
-        ip_str = conn.headers['CF-Connecting-IP']
-    else:
-        # if the request has been forwarded, get the origin
-        forwards = conn.headers['X-Forwarded-For'].split(',')
-        if len(forwards) != 1:
-            ip_str = forwards[0]
+    forwards = conn.headers['X-Forwarded-For'].split(',')
+    if len(forwards) != 1:
+        ip_str = forwards[0]
         else:
             ip_str = conn.headers['X-Real-IP']
 

--- a/domains/osu.py
+++ b/domains/osu.py
@@ -2358,15 +2358,10 @@ async def register_account(
                 # network tab of cloudflare, so it sends the iso code.
                 country_acronym = conn.headers['CF-IPCountry']
             else:
-                # backup method, get the user's ip and
-                # do a db lookup to get their country.
-                if 'CF-Connecting-IP' in conn.headers:
-                    ip_str = conn.headers['CF-Connecting-IP']
-                else:
-                    # if the request has been forwarded, get the origin
-                    forwards = conn.headers['X-Forwarded-For'].split(',')
-                    if len(forwards) != 1:
-                        ip_str = forwards[0]
+                # if the request has been forwarded, get the origin
+                forwards = conn.headers['X-Forwarded-For'].split(',')
+                if len(forwards) != 1:
+                    ip_str = forwards[0]
                     else:
                         ip_str = conn.headers['X-Real-IP']
 


### PR DESCRIPTION
An exploit was recently found, mainly in Ripple stacks (but also present in servers that utilize the CF-Connecting-IP header to find and set the user's IP), that allows players to essentially spoof their IP and location using CF-Connecting-IP. This was brought up (rather helpfully) by @RealistikDash. The main issue is that if the server allows the IP to be set using said header, the player can pretty much change it and then use it freely. Servers, including ones like gulag and Asahi that do not use Cloudflare or has a server switcher, it is vulnerable.

Just thought I'd PR this; entirely up to you if you wanna take the risk.