### PR TITLE
ubuntu 20.04 support

### DIFF
--- a/ext/nginx.conf
+++ b/ext/nginx.conf
@@ -20,6 +20,7 @@ server {
 
 	ssl_certificate     /etc/letsencrypt/live/cmyui.xyz/fullchain.pem;
 	ssl_certificate_key /etc/letsencrypt/live/cmyui.xyz/privkey.pem;
+	ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:@SECLEVEL=1";
 
 	client_max_body_size 64m;
 
@@ -39,6 +40,7 @@ server {
 
 	ssl_certificate     /etc/letsencrypt/live/cmyui.xyz/fullchain.pem;
 	ssl_certificate_key /etc/letsencrypt/live/cmyui.xyz/privkey.pem;
+	ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:@SECLEVEL=1";
 
 	location / {
 		default_type image/png;
@@ -54,6 +56,7 @@ server {
 #
 #	ssl_certificate     /path/to/ppy_sh/cert.pem;
 #	ssl_certificate_key /path/to/ppy_sh/key.pem;
+#	ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:@SECLEVEL=1";
 #
 #	client_max_body_size 64m;
 #
@@ -73,6 +76,7 @@ server {
 #
 #	ssl_certificate     /path/to/ppy_sh/cert.pem;
 #	ssl_certificate_key /path/to/ppy_sh/key.pem;
+#	ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:@SECLEVEL=1";
 #
 #	location / {
 #		default_type image/png;


### PR DESCRIPTION
this worked on ubuntu 20.04

closes #107 

todo maybe update the readme for 20.04 as well, cuz now u can just `apt install python3.9 python3-pip`. also python3.9-dev and python3.9-distutils don't seem to be needed

o btw instead of `git submodule init && git submodule update` just git clone `--recursive`.

o and gulag builds oppai for u so that part can be omitted too