### PR TITLE
refactor installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ the new stack; the code will need to be of comparable quality to what you see he
 
 # Installation Guide
 
-## Important notes:
+**Important notes:**
 - gulag currently does not work on most other distros besides ubuntu 18.04 and 20.04 due to an issue with the liboppai library.
 - osu uses the old deprecated TLSv1.0 so you will need to make sure your reverse proxy supports TLSv1.0. The included nginx configuration should enable TLSv1.0 on 20.04.
 
@@ -124,7 +124,7 @@ Test the server:
 ## Install gulag as a daemon for production
 Move gulag to a system-wide location and create a system user for it (optional, recommended for security but may make things harder to work with)
 ```sh
-sudo mv gulag /srv/gulag
+sudo mv gulag /srv/gulag # don't forget to update paths in nginx
 sudo useradd -r gulag
 sudo chown -R gulag:gulag /srv/gulag
 sudo chmod 640 /srv/gulag/config.py # protect credentials

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ the new stack; the code will need to be of comparable quality to what you see he
 # Installation Guide
 
 **Important notes:**
-- gulag currently does not work on most other distros besides ubuntu 18.04 and 20.04 due to an issue with the liboppai library.
+- gulag currently does not work on most other distros besides ubuntu 18.04 and 20.04 due to an unknown issue with the liboppai library.
 - osu uses the old deprecated TLSv1.0 so you will need to make sure your reverse proxy supports TLSv1.0. The included nginx configuration should enable TLSv1.0 on 20.04.
 
 ## Install requirements

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ the new stack; the code will need to be of comparable quality to what you see he
 ## Install requirements
 Ubuntu 20.04 has python3.9 so you can simply do:
 ```sh
-sudo apt install python3.9 python3-pip build-essential mysql-server nginx certbot
+sudo apt install python3.9 python3-pip build-essential mysql-server nginx python3-certbot python3-certbot-nginx
 ```
 For 18.04 you'll need to use the ppa:
 ```sh
 sudo add-apt-repository ppa:deadsnakes/ppa
-sudo apt install python3.9 python3.9-dev python3.9-distutils mysql-server nginx build-essential certbot
+sudo apt install python3.9 python3.9-dev python3.9-distutils build-essential mysql-server nginx python3-certbot python3-certbot-nginx
 wget https://bootstrap.pypa.io/get-pip.py
 python3.9 get-pip.py && rm get-pip.py
 ```

--- a/README.md
+++ b/README.md
@@ -59,78 +59,91 @@ there is a pretty decent chance that [varkaria](https://github.com/Varkaria) and
 i will be doing some major refactoring in the future before moving akatsuki onto
 the new stack; the code will need to be of comparable quality to what you see here.
 
-Installation Guide
--------------
-important notes:
-- ubuntu 20.04 & nginx have unknown issues? i recommend using 18.04
-- i will not help with the creation of a fake *.ppy.sh cert for switcher support.
 
+# Installation Guide
+
+## Important notes:
+- gulag currently does not work on most other distros besides ubuntu 18.04 and 20.04 due to an issue with the liboppai library.
+- osu uses the old deprecated TLSv1.0 so you will need to make sure your reverse proxy supports TLSv1.0. The included nginx configuration should enable TLSv1.0 on 20.04.
+
+## Install requirements
+Ubuntu 20.04 has python3.9 so you can simply do:
 ```sh
-# add ppa for py3.9 (i love asottile)
+sudo apt install python3.9 python3-pip build-essential mysql-server nginx certbot
+```
+For 18.04 you'll need to use the ppa:
+```sh
 sudo add-apt-repository ppa:deadsnakes/ppa
-
-# install requirements (py3.9, mysql, nginx, build tools, certbot)
-sudo apt install python3.9 python3.9-dev python3.9-distutils \
-                 mysql-server nginx build-essential certbot
-
-# install pip for py3.9
+sudo apt install python3.9 python3.9-dev python3.9-distutils mysql-server nginx build-essential certbot
 wget https://bootstrap.pypa.io/get-pip.py
 python3.9 get-pip.py && rm get-pip.py
+```
+Clone the repository and install pip requirements:
+```sh
+git clone https://github.com/cmyui/gulag.git --recursive && cd gulag
+sudo python3.9 -m pip install -r ext/requirements.txt
+```
 
-# clone the repo & init submodules
-git clone https://github.com/cmyui/gulag.git && cd gulag
-git submodule init && git submodule update
+## Set up mysql
+Create an empty database for gulag: run `sudo mysql` to open a mysql shell and run these commands:
+```sql
+CREATE DATABASE gulag;
+CREATE USER 'gulag' IDENTIFIED BY 'make_a_random_password_here';
+GRANT ALL PRIVILEGES ON gulag.* TO 'gulag';
+FLUSH PRIVILEGES;
+exit
+```
+Import gulag's sql structure:
+```sh
+mysql -p -u gulag gulag < ext/db.sql
+```
 
-# install gulag requirements w/ pip
-python3.9 -m pip install -r ext/requirements.txt
-
-# build oppai-ng's static library
-cd oppai-ng && ./libbuild && cd ..
-
-######################################
-# NOTE: before continuing, create an #
-# empty database in mysql for gulag  #
-######################################
-
-# import gulag's mysql structure
-mysql -u your_sql_username -p your_db_name < ext/db.sql
-
-# generate an ssl certificate for your domain (change email & domain)
-sudo certbot certonly \
-    --manual \
-    --preferred-challenges=dns \
-    --email your@email.com \
-    --server https://acme-v02.api.letsencrypt.org/directory \
-    --agree-tos \
-    -d *.your.domain
-
-# copy our nginx config to `sites-enabled` & open for editing
-sudo cp ext/nginx.conf /etc/nginx/sites-enabled/gulag.conf
-sudo nano /etc/nginx/sites-enabled/gulag.conf
-
-##########################################
-# NOTE: before continuing, make sure you #
-# have completely configured the file.   #
-##########################################
-
-# reload the reverse proxy's config
+## Set up nginx and certificates
+Create a TLS certificate for your domain:
+```sh
+D=your.domain certbot certonly --nginx -d osu.$D,a.$D,b.$D,c.$D,c4.$D,c5.$D,c6.$D,ce.$D,assets.$D
+```
+Copy and edit the nginx configuration with your domain:
+```sh
+sudo cp ext/nginx.conf /etc/nginx/conf.d/gulag.conf
+sudo nano /etc/nginx/conf.d/gulag.conf
 sudo nginx -s reload
+```
 
-# copy our gulag config to cwd & open for editing
+## Configure and run gulag
+Copy and edit gulag's config file:
+```sh
 cp ext/config.sample.py config.py
 nano config.py
-
-##########################################
-# NOTE: before continuing, make sure you #
-# have completely configured the file.   #
-##########################################
-
-# start the server
+```
+Test the server:
+```sh
 ./main.py
 ```
 
-Directory Structure
-------
+## Install gulag as a daemon for production
+Move gulag to a system-wide location and create a system user for it (optional, recommended for security but may make things harder to work with)
+```sh
+sudo mv gulag /srv/gulag
+sudo useradd -r gulag
+sudo chown -R gulag:gulag /srv/gulag
+sudo chmod 640 /srv/gulag/config.py # protect credentials
+```
+Copy and edit the systemd service file:
+```sh
+sudo cp ext/gulag.service /etc/systemd/system/
+sudo nano /etc/systemd/system/gulag.service
+sudo systemctl daemon-reload
+```
+Make sure gulag isn't running elsewhere. Enable and start the service:
+```sh
+sudo systemctl enable --now gulag
+```
+You can view log output with `tail -f /var/log/gulag.log`.
+
+
+# Directory Structure
+
     .
     ├── constants  # code representing gamemodes, mods, privileges, and other constants.
     ├── ext        # external files from gulag's primary operation.


### PR DESCRIPTION
- supports 18.04 & 20.04, adds some important information.
- shows how to prepare mysql for gulag
- I changed the certbot command to use nginx plugin with list of domains instead of manual dns for wildcard; This way user only needs to run the one command and automatic renewal will work. The other way requires more complication and manual renewal.
- systemd service info

let me know what you think; may want revising

this pr depends on other pr's.

